### PR TITLE
Remove practice mode rule

### DIFF
--- a/resources/submission_rules.md
+++ b/resources/submission_rules.md
@@ -2,22 +2,20 @@
 
 2. Custom icon texture packs are allowed, but your icon must still look like an icon (no faces or heavily altered designs). Level object-altering texture packs are not allowed.
 
-3. Practice checkpoints cannot be visible in the thumbnail (in-level checkpoints such as platformer checkpoints are allowed).
+3. Please show the gameplay of the level, title cards and transitions are not allowed.
 
-4. Please show the gameplay of the level, title cards and transitions are not allowed.
+4. Particles (such as around orbs and portals) and shaders should be enabled, and LDM should be off in Main Menu > Settings > Help.
 
-5. Particles (such as around orbs and portals) and shaders should be enabled, and LDM should be off in Main Menu > Settings > Help.
+5. Do not use a level's built-in LDM.
 
-6. Do not use a level's built-in LDM.
+6. Hitboxes, death effects, and spawn effects are not allowed.
 
-7. Hitboxes, death effects, and spawn effects are not allowed.
+7. You cannot be close to death in your thumbnail.
 
-8. You cannot be close to death in your thumbnail.
+8. Avoid submitting the first couple percentages of the level if possible, please use an actually good part in the level, show the best/most fun looking part.
 
-9. Avoid submitting the first couple percentages of the level if possible, please use an actually good part in the level, show the best/most fun looking part.
+9. Use high graphics settings (Main Menu > Settings > Graphics, if you're on mobile use the High Graphics on Mobile mod).
 
-10. Use high graphics settings (Main Menu > Settings > Graphics, if you're on mobile use the High Graphics on Mobile mod).
+10. If your thumbnail is glitched in any way during the preview (like due to a bug in the mod), do NOT submit it.
 
-11. If your thumbnail is glitched in any way during the preview (like due to a bug in the mod), do NOT submit it.
-
-12. Avoid submitting thumbnails for random recent tab levels, there are a LOT of thumbnails for the mods to go through and little Timmy levels do not need thumbnails.
+11. Avoid submitting thumbnails for random recent tab levels, there are a LOT of thumbnails for the mods to go through and little Timmy levels do not need thumbnails.


### PR DESCRIPTION
This is because they already go away by default in the thumbnails 
![a](https://tinyurl.com/mugaking)